### PR TITLE
Add delete functionality to event cards

### DIFF
--- a/components/admin/delete-event-button.tsx
+++ b/components/admin/delete-event-button.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Trash2 } from 'lucide-react';
+
+import { deleteEvent } from '@/actions/event-actions';
+import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+
+interface DeleteEventButtonProps {
+  eventId: string;
+  eventTitle: string;
+}
+
+export function DeleteEventButton({
+  eventId,
+  eventTitle,
+}: DeleteEventButtonProps) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    setError(null);
+    try {
+      await deleteEvent(eventId);
+      setOpen(false);
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete event');
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>
+        <Button
+          variant='outline'
+          className='text-destructive hover:text-destructive hover:bg-destructive/10 border-destructive/30'
+        >
+          <span className='flex items-center gap-1'>
+            <Trash2 className='h-4 w-4' />
+            Delete
+          </span>
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete this event?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will permanently delete{' '}
+            <span className='font-medium text-foreground'>{eventTitle}</span>.
+            This action cannot be undone. Use this when an event has been
+            cancelled.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        {error && (
+          <p className='text-sm text-destructive' role='alert'>
+            {error}
+          </p>
+        )}
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={event => {
+              event.preventDefault();
+              handleDelete();
+            }}
+            disabled={isDeleting}
+            className='bg-destructive text-destructive-foreground hover:bg-destructive/90'
+          >
+            {isDeleting ? 'Deleting...' : 'Delete Event'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/components/admin/event-card.tsx
+++ b/components/admin/event-card.tsx
@@ -10,6 +10,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
+import { DeleteEventButton } from '@/components/admin/delete-event-button';
 import type { Event } from '@/types/event';
 
 interface EventCardProps {
@@ -63,6 +64,7 @@ export function EventCard({ event, type }: EventCardProps) {
                 </span>
               </Link>
             </Button>
+            <DeleteEventButton eventId={event.id} eventTitle={event.title} />
           </div>
         </div>
       </CardHeader>

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -3,7 +3,7 @@
 import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
 import * as React from 'react';
 
-import { buttonVariants } from '@/components/ui/Button';
+import { buttonVariants } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
 const AlertDialog = AlertDialogPrimitive.Root;


### PR DESCRIPTION
- Added a `DeleteEventButton` to the `EventCard` component, allowing users to remove events directly from the interface.

[v0 Session](https://v0.app/chat/OTAx14aK2hS)